### PR TITLE
Add withCredentials flag to HttpDefaults

### DIFF
--- a/src/main/scala/biz/enef/angulate/core/Http.scala
+++ b/src/main/scala/biz/enef/angulate/core/Http.scala
@@ -147,6 +147,7 @@ trait HttpDefaults extends js.Object {
   def xsrfCookieName: String = js.native
   def xsrfHeaderName: String = js.native
   def headers: js.Dynamic = js.native
+  def withCredentials: Boolean = js.native
 }
 
 trait HttpResponse extends js.Object {


### PR DESCRIPTION
`withCredentials` can also be enabled on all http requests by adding it to the list of default settings.

It's not part of the official AngularJS documentation, but it is referred to by several online tutorials and you can find it here in the official Angular 1.x specs: https://github.com/angular/angular.js/blob/291d7c467fba51a9cb89cbeee62202d51fe64b09/test/ng/httpSpec.js#L1886

```
inject(function($http, $rootScope) {
   $http.defaults.withCredentials = true;
   $http({ ... });
}
```
