### PR TITLE
make angulate compile with scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,18 @@
 
 lazy val commonSettings = Seq(
   organization := "biz.enef",
-  version := "0.2.4",
-  scalaVersion := "2.11.8",
+  version := "0.2.5-SNAPSHOT",
+  scalaVersion := "2.12.5",
   scalacOptions ++= Seq("-deprecation","-unchecked","-feature","-language:implicitConversions","-Xlint"),
   autoCompilerPlugins := true,
-  addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.2"),
-  libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided",
+  addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
+  libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided",
   scalacOptions ++= (if (isSnapshot.value) Seq.empty else Seq({
         val a = baseDirectory.value.toURI.toString.replaceFirst("[^/]+/?$", "")
         val g = "https://raw.githubusercontent.com/jokade/scalajs-angulate"
         s"-P:scalajs:mapSourceURI:$a->$g/v${version.value}/"
-      }))
+      })),
+  resolvers += Resolver.sonatypeRepo("snapshots")
 )
 
 
@@ -23,10 +24,12 @@ lazy val root = project.in(file(".")).
     name := "scalajs-angulate",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-      "org.scala-js"   %%% "scalajs-dom" % "0.8.0",
-      "be.doeraene" %%% "scalajs-jquery" % "0.8.0" % "provided"
+      "org.scala-js"   %%% "scalajs-dom" % "0.9.5",
+      "de.surfice"     %%% "smacrotools-sjs"  % "0.0.8",
+      "be.doeraene" %%% "scalajs-jquery" % "0.9.3" % "provided"
     ),
-    resolvers += Resolver.sonatypeRepo("releases")
+    resolvers += Resolver.sonatypeRepo("releases"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
   )
 
 
@@ -40,8 +43,8 @@ lazy val tests = project.
     scalaJSStage in Test := FastOptStage,
     testFrameworks += new TestFramework("utest.runner.Framework"),
     requiresDOM := true,
-    libraryDependencies ++= Seq("com.lihaoyi" %%% "utest" % "0.3.0" % "test",
-      "be.doeraene" %%% "scalajs-jquery" % "0.8.0"),
+    libraryDependencies ++= Seq("com.lihaoyi" %%% "utest" % "0.4.4" % "test",
+      "be.doeraene" %%% "scalajs-jquery" % "0.9.1"),
     jsDependencies += RuntimeDOM,
     jsDependencies += "org.webjars" % "angularjs" % "1.3.8" / "angular.min.js" % "test",
     jsDependencies += ("org.webjars" % "angularjs" % "1.3.8" / "angular-mocks.js" dependsOn "angular.min.js") % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 

--- a/src/main/scala/biz/enef/angulate/core/impl/HttpMacros.scala
+++ b/src/main/scala/biz/enef/angulate/core/impl/HttpMacros.scala
@@ -120,6 +120,10 @@ class HttpPromiseWrapper[T](wrapped: HttpPromise[T]) extends Future[T] {
   override def result(atMost: Duration)(implicit permit: CanAwait): T = future.result(atMost)
 
   override def ready(atMost: Duration)(implicit permit: CanAwait): this.type = {future.ready(atMost);this}
+
+  def transform[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S] = future.transform(f)
+
+  def transformWith[S](f: Try[T] => Future[S])(implicit executor: ExecutionContext): Future[S] = future.transformWith(f)
 }
 
 @JSExportAll


### PR DESCRIPTION
Based it on the latest release 0.2.4 not on the head

Bumped version (often as little as needed) to make it compile. Added the
new `Future` methods to `HttpPromiseWrapper`